### PR TITLE
Fix mobile dashboard header layout overlap

### DIFF
--- a/__tests__/dashboard/page.test.jsx
+++ b/__tests__/dashboard/page.test.jsx
@@ -59,6 +59,7 @@ jest.mock("@/components/ui/popover", () => ({
 
 jest.mock("lucide-react", () => ({
   CalendarIcon: () => <span>CalendarIcon</span>,
+  FilePlusCorner: () => <span>FilePlusCorner</span>,
 }));
 
 import userEvent from "@testing-library/user-event";

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
+import { CalendarIcon, FilePlusCorner } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
@@ -64,7 +64,8 @@ export default function DashboardClient({
         <div className="flex items-center gap-2">
           <Link href="/dashboard/workout/new">
             <Button>
-              Log New Workout
+              <FilePlusCorner className="size-4 md:hidden" />
+              <span className="hidden md:inline">Log New Workout</span>
             </Button>
           </Link>
           <Popover>
@@ -72,7 +73,7 @@ export default function DashboardClient({
               render={<Button variant="outline" className="gap-2" />}
             >
               <CalendarIcon className="size-4" />
-              {format(date, "do MMM yyyy")}
+              <span className="hidden md:inline">{format(date, "do MMM yyyy")}</span>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="end">
               <Calendar


### PR DESCRIPTION
## Summary
Fix layout overlap on mobile dashboard by showing icon-only buttons instead of full text labels.

## Changes
- Replace "Log New Workout" text button with a `FilePlusCorner` icon on mobile, keeping full text on desktop via `md:` breakpoint
- Hide date picker text label on mobile, showing only the calendar icon
- Update test mocks to include the new `FilePlusCorner` icon

## Related Issue
Related to #1 

## Screenshots (if applicable)
AS-IS | TO-BE
--|--
<img width="320" src="https://github.com/user-attachments/assets/9b09177b-8579-407a-ac20-a427eb1591f0" /> | <img width="320" src="https://github.com/user-attachments/assets/4821d8ca-6524-45a6-87a2-67c3266fc2b5" />

## Notes
Uses Tailwind responsive utilities (`hidden md:inline`, `md:hidden`) for the toggle — no JS required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)