### PR TITLE
Add delete workout feature with confirmation dialog

### DIFF
--- a/__tests__/dashboard/delete-workout-dialog.test.jsx
+++ b/__tests__/dashboard/delete-workout-dialog.test.jsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockRefresh = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, disabled, ...props }) => (
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+let dialogOnOpenChange;
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open, onOpenChange }) => {
+    dialogOnOpenChange = onOpenChange;
+    return <div>{children}</div>;
+  },
+  DialogTrigger: ({ children, render }) => {
+    const onClick = render?.props?.onClick;
+    return (
+      <button
+        data-testid="delete-trigger"
+        onClick={(e) => {
+          if (onClick) onClick(e);
+          if (dialogOnOpenChange) dialogOnOpenChange(true);
+        }}
+      >
+        {children}
+      </button>
+    );
+  },
+  DialogContent: ({ children }) => <div>{children}</div>,
+  DialogHeader: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <h2>{children}</h2>,
+  DialogFooter: ({ children }) => <div>{children}</div>,
+  DialogClose: ({ children, render }) => {
+    const onClick = render?.props?.onClick;
+    return (
+      <button
+        onClick={(e) => {
+          if (onClick) onClick(e);
+          if (dialogOnOpenChange) dialogOnOpenChange(false);
+        }}
+      >
+        {children}
+      </button>
+    );
+  },
+}));
+
+jest.mock("lucide-react", () => ({
+  Trash2: () => <span>TrashIcon</span>,
+}));
+
+const mockDeleteAction = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/app/dashboard/actions", () => ({
+  deleteWorkoutAction: (...args) => mockDeleteAction(...args),
+}));
+
+import { useRouter } from "next/navigation";
+import DeleteWorkoutDialog from "@/app/dashboard/delete-workout-dialog";
+
+describe("DeleteWorkoutDialog", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dialogOnOpenChange = undefined;
+    useRouter.mockReturnValue({ push: jest.fn(), refresh: mockRefresh });
+  });
+
+  it("renders the trash icon trigger", () => {
+    render(<DeleteWorkoutDialog workoutId="w1" workoutName="Leg Day" />);
+    expect(screen.getByText("TrashIcon")).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog with workout name", () => {
+    render(<DeleteWorkoutDialog workoutId="w1" workoutName="Leg Day" />);
+
+    act(() => { dialogOnOpenChange(true); });
+
+    expect(screen.getByText("Delete Workout?")).toBeInTheDocument();
+    expect(screen.getByText("Leg Day")).toBeInTheDocument();
+    expect(screen.getByText(/This action cannot be undone/)).toBeInTheDocument();
+  });
+
+  it("calls deleteWorkoutAction and refreshes on confirm", async () => {
+    const user = userEvent.setup();
+    render(<DeleteWorkoutDialog workoutId="w1" workoutName="Leg Day" />);
+
+    await user.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(mockDeleteAction).toHaveBeenCalledWith({ workoutId: "w1" });
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("does not delete when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DeleteWorkoutDialog workoutId="w1" workoutName="Leg Day" />);
+
+    await user.click(screen.getByText("Cancel"));
+
+    expect(mockDeleteAction).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("disables Delete button while pending", async () => {
+    let resolveAction;
+    mockDeleteAction.mockImplementation(
+      () => new Promise((resolve) => { resolveAction = resolve; })
+    );
+
+    const user = userEvent.setup();
+    render(<DeleteWorkoutDialog workoutId="w1" workoutName="Leg Day" />);
+
+    await user.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Deleting...")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Deleting...")).toBeDisabled();
+
+    resolveAction(undefined);
+
+    await waitFor(() => {
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/dashboard/page.test.jsx
+++ b/__tests__/dashboard/page.test.jsx
@@ -61,6 +61,7 @@ jest.mock("lucide-react", () => ({
   CalendarIcon: () => <span>CalendarIcon</span>,
   FilePlusCorner: () => <span>FilePlusCorner</span>,
   Copy: () => <span>CopyIcon</span>,
+  Trash2: () => <span>TrashIcon</span>,
 }));
 
 jest.mock("@/components/ui/dialog", () => ({
@@ -75,6 +76,7 @@ jest.mock("@/components/ui/dialog", () => ({
 
 jest.mock("@/app/dashboard/actions", () => ({
   duplicateWorkoutAction: jest.fn().mockResolvedValue({ id: "new-workout-id" }),
+  deleteWorkoutAction: jest.fn().mockResolvedValue(undefined),
 }));
 
 import userEvent from "@testing-library/user-event";
@@ -124,8 +126,8 @@ describe("DashboardClient", () => {
 
     render(<DashboardClient dateString="2026-03-16" workouts={workouts} />);
 
-    expect(screen.getByText("Upper Body")).toBeInTheDocument();
-    expect(screen.getByText("Leg Day")).toBeInTheDocument();
+    expect(screen.getAllByText("Upper Body").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Leg Day").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows completion badge for completed workouts", () => {

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,8 +1,18 @@
 "use server";
 
 import { z } from "zod";
-import { duplicateWorkout } from "@/data/workouts";
+import { deleteWorkout, duplicateWorkout } from "@/data/workouts";
 import { getAuthenticatedUser } from "@/lib/auth";
+
+const DeleteWorkoutSchema = z.object({
+  workoutId: z.string().uuid(),
+});
+
+export async function deleteWorkoutAction(params: { workoutId: string }) {
+  const user = await getAuthenticatedUser();
+  const validated = DeleteWorkoutSchema.parse(params);
+  await deleteWorkout(validated.workoutId, user.id);
+}
 
 const DuplicateWorkoutSchema = z.object({
   workoutId: z.string().uuid(),

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
 import { CalendarIcon, FilePlusCorner } from "lucide-react";
+import DeleteWorkoutDialog from "./delete-workout-dialog";
 import DuplicateWorkoutDialog from "./duplicate-workout-dialog";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -107,6 +108,7 @@ export default function DashboardClient({
                       <CardTitle className="font-bold">{workout.name}</CardTitle>
                       <div onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
                         <DuplicateWorkoutDialog workoutId={workout.id} />
+                        <DeleteWorkoutDialog workoutId={workout.id} workoutName={workout.name} />
                       </div>
                     </div>
                     <span className="text-sm text-muted-foreground" suppressHydrationWarning>

--- a/src/app/dashboard/delete-workout-dialog.tsx
+++ b/src/app/dashboard/delete-workout-dialog.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { deleteWorkoutAction } from "./actions";
+
+interface DeleteWorkoutDialogProps {
+  workoutId: string;
+  workoutName: string;
+}
+
+export default function DeleteWorkoutDialog({
+  workoutId,
+  workoutName,
+}: DeleteWorkoutDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+
+  async function handleConfirm() {
+    setIsPending(true);
+    try {
+      await deleteWorkoutAction({ workoutId });
+      setOpen(false);
+      router.refresh();
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          />
+        }
+      >
+        <Trash2 className="size-4 text-destructive" />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Workout?</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground py-4">
+          Are you sure you want to delete{" "}
+          <span className="font-medium text-foreground">{workoutName}</span>?
+          This action cannot be undone.
+        </p>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>
+            Cancel
+          </DialogClose>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+          >
+            {isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/data/workouts.ts
+++ b/src/data/workouts.ts
@@ -110,6 +110,12 @@ export async function duplicateWorkout(
   return newWorkout;
 }
 
+export async function deleteWorkout(workoutId: string, userId: string) {
+  return db
+    .delete(workouts)
+    .where(and(eq(workouts.id, workoutId), eq(workouts.userId, userId)));
+}
+
 export async function getWorkoutsByDate(dateString: string) {
   const user = await getAuthenticatedUser();
 


### PR DESCRIPTION
## Summary

Add the ability for users to delete workouts from the dashboard with a confirmation dialog to prevent accidental deletions.

## Changes

- Add `DeleteWorkoutDialog` component with trash icon trigger and confirmation prompt
- Add `deleteWorkoutAction` server action with Zod validation
- Add `deleteWorkout` data layer function scoped to the authenticated user
- Integrate delete button alongside existing duplicate button on workout cards
- Add comprehensive tests for the delete dialog and update existing dashboard tests

## Related Issue

Related to #7 

## Screenshots
AS-IS | TO-BE
--|--
<img width="320" src="https://github.com/user-attachments/assets/8074b0d6-ed72-40a6-b1cb-6bc29e2e6b85" /> | <img width="320" src="https://github.com/user-attachments/assets/575d0346-51cc-4018-8a4b-d7438549da07" />

## Notes

- The delete operation is scoped by `userId` to ensure users can only delete their own workouts.
- The dialog shows the workout name and warns that the action cannot be undone.
- The Delete button shows a "Deleting..." state while the action is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)