### PR TITLE
Add user settings page with profile, location auto-detection, and appearance

### DIFF
--- a/__tests__/dashboard/page.test.jsx
+++ b/__tests__/dashboard/page.test.jsx
@@ -62,6 +62,7 @@ jest.mock("lucide-react", () => ({
   FilePlusCorner: () => <span>FilePlusCorner</span>,
   Copy: () => <span>CopyIcon</span>,
   Trash2: () => <span>TrashIcon</span>,
+  Settings: () => <span>SettingsIcon</span>,
 }));
 
 jest.mock("@/components/ui/dialog", () => ({

--- a/__tests__/dashboard/settings/page.test.jsx
+++ b/__tests__/dashboard/settings/page.test.jsx
@@ -1,0 +1,239 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("next-themes", () => ({
+  useTheme: jest.fn().mockReturnValue({ theme: "system", setTheme: jest.fn() }),
+}));
+
+const mockOpenUserProfile = jest.fn();
+
+jest.mock("@clerk/nextjs", () => ({
+  useUser: jest.fn().mockReturnValue({
+    user: {
+      fullName: "John Doe",
+      firstName: "John",
+      lastName: "Doe",
+      imageUrl: "https://example.com/avatar.jpg",
+      primaryEmailAddress: { emailAddress: "john@example.com" },
+      externalAccounts: [
+        {
+          id: "ea_1",
+          provider: "google",
+          emailAddress: "john@gmail.com",
+          verification: { status: "verified" },
+        },
+      ],
+    },
+  }),
+  useClerk: () => ({
+    openUserProfile: mockOpenUserProfile,
+  }),
+}));
+
+jest.mock("lucide-react", () => ({
+  ArrowLeft: () => <span>ArrowLeft</span>,
+  Sun: () => <span>Sun</span>,
+  Moon: () => <span>Moon</span>,
+  Monitor: () => <span>Monitor</span>,
+  ExternalLink: () => <span>ExternalLink</span>,
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+}));
+
+jest.mock("@/components/ui/input", () => ({
+  Input: (props) => <input {...props} />,
+}));
+
+jest.mock("@/components/ui/label", () => ({
+  Label: ({ children, ...props }) => <label {...props}>{children}</label>,
+}));
+
+jest.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }) => <div {...props}>{children}</div>,
+  CardTitle: ({ children, ...props }) => <h3 {...props}>{children}</h3>,
+}));
+
+jest.mock("@/components/ui/avatar", () => ({
+  Avatar: ({ children, ...props }) => <div {...props}>{children}</div>,
+  AvatarImage: ({ alt, ...props }) => <img alt={alt} {...props} />,
+  AvatarFallback: ({ children, ...props }) => <span {...props}>{children}</span>,
+}));
+
+jest.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...props }) => <span {...props}>{children}</span>,
+}));
+
+jest.mock("@/components/ui/select", () => ({
+  Select: ({ children, value, onValueChange: _onValueChange }) => (
+    <div data-testid="select" data-value={value}>
+      {children}
+    </div>
+  ),
+  SelectContent: ({ children }) => <div>{children}</div>,
+  SelectGroup: ({ children }) => <div>{children}</div>,
+  SelectItem: ({ children, value }) => <option value={value}>{children}</option>,
+  SelectLabel: ({ children }) => <span>{children}</span>,
+  SelectTrigger: ({ children }) => <button>{children}</button>,
+  SelectValue: () => <span>SelectValue</span>,
+}));
+
+jest.mock("@/components/ui/separator", () => ({
+  Separator: () => <hr />,
+}));
+
+jest.mock("@/app/dashboard/settings/actions", () => ({
+  updateLocationSettingsAction: jest.fn().mockResolvedValue([{}]),
+}));
+
+import { useTheme } from "next-themes";
+import { useUser } from "@clerk/nextjs";
+import SettingsClient from "@/app/dashboard/settings/settings-client";
+
+describe("SettingsClient", () => {
+  const defaultSettings = {
+    country: null,
+    city: null,
+    timezone: null,
+  };
+
+  beforeEach(() => {
+    mockOpenUserProfile.mockClear();
+  });
+
+  it("renders the settings heading", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("renders the back link to dashboard", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    const backLink = screen.getByText("ArrowLeft").closest("a");
+    expect(backLink).toHaveAttribute("href", "/dashboard");
+  });
+
+  it("renders user avatar with image", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    const avatar = screen.getByAltText("John Doe");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveAttribute("src", "https://example.com/avatar.jpg");
+  });
+
+  it("renders user name and email", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("john@example.com")).toBeInTheDocument();
+  });
+
+  it("renders avatar fallback initials", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("JD")).toBeInTheDocument();
+  });
+
+  it("renders Profile section title", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+  });
+
+  it("renders Connected Accounts section with provider", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Connected Accounts")).toBeInTheDocument();
+    expect(screen.getByText("Google")).toBeInTheDocument();
+    expect(screen.getByText("john@gmail.com")).toBeInTheDocument();
+    expect(screen.getByText("Connected")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no external accounts", () => {
+    useUser.mockReturnValue({
+      user: {
+        fullName: "Jane Doe",
+        firstName: "Jane",
+        lastName: "Doe",
+        imageUrl: "https://example.com/avatar.jpg",
+        primaryEmailAddress: { emailAddress: "jane@example.com" },
+        externalAccounts: [],
+      },
+    });
+
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("No connected accounts")).toBeInTheDocument();
+  });
+
+  it("calls openUserProfile when Manage Account is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SettingsClient settings={defaultSettings} />);
+
+    await user.click(screen.getByText("Manage Account"));
+    expect(mockOpenUserProfile).toHaveBeenCalled();
+  });
+
+  it("renders Appearance section with theme buttons", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.getByText("Light")).toBeInTheDocument();
+    expect(screen.getByText("Dark")).toBeInTheDocument();
+    expect(screen.getByText("System")).toBeInTheDocument();
+  });
+
+  it("calls setTheme when theme button is clicked", async () => {
+    const setTheme = jest.fn();
+    useTheme.mockReturnValue({ theme: "system", setTheme });
+
+    const user = userEvent.setup();
+    render(<SettingsClient settings={defaultSettings} />);
+
+    await user.click(screen.getByText("Dark"));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+
+    await user.click(screen.getByText("Light"));
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("renders Location & Timezone section", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Location & Timezone")).toBeInTheDocument();
+    expect(screen.getByLabelText("Country")).toBeInTheDocument();
+    expect(screen.getByLabelText("City")).toBeInTheDocument();
+    expect(screen.getByText("Timezone")).toBeInTheDocument();
+  });
+
+  it("renders saved settings values", () => {
+    const settings = {
+      country: "New Zealand",
+      city: "Auckland",
+      timezone: "Pacific/Auckland",
+    };
+
+    render(<SettingsClient settings={settings} />);
+
+    expect(screen.getByLabelText("Country")).toHaveValue("New Zealand");
+    expect(screen.getByLabelText("City")).toHaveValue("Auckland");
+  });
+
+  it("renders Save button", () => {
+    render(<SettingsClient settings={defaultSettings} />);
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+
+  it("calls updateLocationSettingsAction when Save is clicked", async () => {
+    const { updateLocationSettingsAction } = jest.requireMock("@/app/dashboard/settings/actions");
+    const user = userEvent.setup();
+    render(<SettingsClient settings={defaultSettings} />);
+
+    const countryInput = screen.getByLabelText("Country");
+    await user.clear(countryInput);
+    await user.type(countryInput, "New Zealand");
+
+    await user.click(screen.getByText("Save"));
+
+    expect(updateLocationSettingsAction).toHaveBeenCalled();
+  });
+});

--- a/__tests__/layout.test.jsx
+++ b/__tests__/layout.test.jsx
@@ -22,8 +22,12 @@ jest.mock("@/components/theme-provider", () => ({
   ThemeProvider: ({ children }) => <div>{children}</div>,
 }));
 
-jest.mock("@/components/theme-toggle", () => ({
-  ThemeToggle: () => <button>ThemeToggle</button>,
+jest.mock("@/components/settings-initializer", () => ({
+  SettingsInitializer: () => null,
+}));
+
+jest.mock("@/components/ui/sonner", () => ({
+  Toaster: () => null,
 }));
 
 import RootLayout from "@/app/layout";
@@ -72,16 +76,6 @@ describe("RootLayout", () => {
 
     expect(screen.getByText("Sign In")).toBeInTheDocument();
     expect(screen.getByText("Sign Up")).toBeInTheDocument();
-  });
-
-  it("renders theme toggle", () => {
-    render(
-      <RootLayout>
-        <div>Content</div>
-      </RootLayout>
-    );
-
-    expect(screen.getByText("ThemeToggle")).toBeInTheDocument();
   });
 
   it("renders UserButton for signed-in state", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^17.3.1",
         "drizzle-orm": "^0.45.1",
         "lucide-react": "^0.577.0",
@@ -23,6 +24,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.3",
         "shadcn": "^4.0.6",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -6502,6 +6504,15 @@
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -13516,6 +13527,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.577.0",
@@ -27,6 +28,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.3",
     "shadcn": "^4.0.6",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
-import { CalendarIcon, FilePlusCorner } from "lucide-react";
+import { CalendarIcon, FilePlusCorner, Settings } from "lucide-react";
 import DeleteWorkoutDialog from "./delete-workout-dialog";
 import DuplicateWorkoutDialog from "./duplicate-workout-dialog";
 import { Button } from "@/components/ui/button";
@@ -86,6 +86,11 @@ export default function DashboardClient({
               />
             </PopoverContent>
           </Popover>
+          <Link href="/dashboard/settings">
+            <Button variant="outline" size="icon">
+              <Settings className="size-4" />
+            </Button>
+          </Link>
         </div>
       </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { getWorkoutsByDate } from "@/data/workouts";
+import { getUserSettings } from "@/data/user-settings";
 import { getAuthenticatedUser } from "@/lib/auth";
 import DashboardClient from "./dashboard-client";
 
@@ -10,12 +11,13 @@ interface DashboardPageProps {
 export default async function DashboardPage({
   searchParams,
 }: DashboardPageProps) {
-  await getAuthenticatedUser();
+  const user = await getAuthenticatedUser();
+  const settings = await getUserSettings(user.id);
 
   const { date: dateParam } = await searchParams;
 
   const dateString = dateParam ?? format(new Date(), "yyyy-MM-dd");
-  const workouts = await getWorkoutsByDate(dateString);
+  const workouts = await getWorkoutsByDate(dateString, settings?.timezone ?? undefined);
 
   return <DashboardClient dateString={dateString} workouts={workouts} />;
 }

--- a/src/app/dashboard/settings/actions.ts
+++ b/src/app/dashboard/settings/actions.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import { z } from "zod";
+import { getUserSettings, upsertUserSettings } from "@/data/user-settings";
+import { getAuthenticatedUser } from "@/lib/auth";
+
+const UpdateLocationSchema = z.object({
+  country: z.string().optional(),
+  city: z.string().optional(),
+  timezone: z.string().optional(),
+});
+
+export async function updateLocationSettingsAction(params: {
+  country?: string;
+  city?: string;
+  timezone?: string;
+}) {
+  const user = await getAuthenticatedUser();
+  const validated = UpdateLocationSchema.parse(params);
+  return upsertUserSettings(user.id, validated);
+}
+
+export async function initializeSettingsAction(browser: {
+  timezone: string;
+  country: string;
+  city: string;
+}) {
+  const user = await getAuthenticatedUser();
+  const settings = await getUserSettings(user.id);
+
+  const updates: { timezone?: string; country?: string; city?: string } = {};
+  if (!settings?.timezone && browser.timezone) updates.timezone = browser.timezone;
+  if (!settings?.country && browser.country) updates.country = browser.country;
+  if (!settings?.city && browser.city) updates.city = browser.city;
+
+  if (Object.keys(updates).length === 0) return;
+  await upsertUserSettings(user.id, updates);
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,14 @@
+import { getAuthenticatedUser } from "@/lib/auth";
+import { getUserSettings } from "@/data/user-settings";
+import SettingsClient from "./settings-client";
+
+export default async function SettingsPage() {
+  const user = await getAuthenticatedUser();
+  const settings = await getUserSettings(user.id);
+
+  return (
+    <SettingsClient
+      settings={settings ?? { country: null, city: null, timezone: null }}
+    />
+  );
+}

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, useTransition, useMemo } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { useUser, useClerk } from "@clerk/nextjs";
+import { ArrowLeft, Sun, Moon, Monitor, ExternalLink } from "lucide-react";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { updateLocationSettingsAction } from "./actions";
+
+interface SettingsClientProps {
+  settings: {
+    country: string | null;
+    city: string | null;
+    timezone: string | null;
+  };
+}
+
+function getInitials(firstName?: string | null, lastName?: string | null) {
+  const first = firstName?.[0] ?? "";
+  const last = lastName?.[0] ?? "";
+  return (first + last).toUpperCase() || "?";
+}
+
+function formatProvider(provider: string) {
+  const names: Record<string, string> = {
+    google: "Google",
+    apple: "Apple",
+    github: "GitHub",
+    facebook: "Facebook",
+    microsoft: "Microsoft",
+    discord: "Discord",
+    twitter: "Twitter",
+    linkedin: "LinkedIn",
+  };
+  return names[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+export default function SettingsClient({ settings }: SettingsClientProps) {
+  const router = useRouter();
+  const { user } = useUser();
+  const clerk = useClerk();
+  const { theme = "system", setTheme } = useTheme();
+  const [isPending, startTransition] = useTransition();
+
+  const [country, setCountry] = useState(settings.country ?? "");
+  const [city, setCity] = useState(settings.city ?? "");
+  const [timezone, setTimezone] = useState(
+    settings.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
+  );
+
+  const timezonesByRegion = useMemo(() => {
+    const zones = Intl.supportedValuesOf("timeZone");
+    const grouped: Record<string, string[]> = {};
+    for (const tz of zones) {
+      const region = tz.split("/")[0];
+      if (!grouped[region]) grouped[region] = [];
+      grouped[region].push(tz);
+    }
+    return grouped;
+  }, []);
+
+  function handleSaveLocation() {
+    startTransition(async () => {
+      await updateLocationSettingsAction({
+        country: country || undefined,
+        city: city || undefined,
+        timezone,
+      });
+      router.refresh();
+    });
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-3">
+        <Link href="/dashboard">
+          <Button variant="outline" size="icon">
+            <ArrowLeft className="size-4" />
+          </Button>
+        </Link>
+        <h2 className="text-2xl font-bold">Settings</h2>
+      </div>
+
+      <div className="space-y-6">
+        {/* Profile */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-4">
+              <Avatar className="size-16">
+                <AvatarImage src={user?.imageUrl} alt={user?.fullName ?? "Profile"} />
+                <AvatarFallback className="text-lg">
+                  {getInitials(user?.firstName, user?.lastName)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="space-y-1">
+                <p className="text-lg font-medium">
+                  {user?.fullName ?? "—"}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {user?.primaryEmailAddress?.emailAddress ?? "—"}
+                </p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => clerk.openUserProfile()}
+            >
+              Manage Account
+              <ExternalLink className="ml-2 size-4" />
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Connected Accounts */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Connected Accounts</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {user?.externalAccounts && user.externalAccounts.length > 0 ? (
+              <div className="space-y-3">
+                {user.externalAccounts.map((account) => (
+                  <div
+                    key={account.id}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div className="space-y-0.5">
+                      <p className="text-sm font-medium">
+                        {formatProvider(account.provider)}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {account.emailAddress ?? "—"}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={
+                        account.verification?.status === "verified"
+                          ? "default"
+                          : "secondary"
+                      }
+                    >
+                      {account.verification?.status === "verified"
+                        ? "Connected"
+                        : "Pending"}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No connected accounts
+              </p>
+            )}
+            <Button
+              variant="outline"
+              onClick={() => clerk.openUserProfile()}
+            >
+              Manage
+              <ExternalLink className="ml-2 size-4" />
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Appearance */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Appearance</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex gap-2">
+              <Button
+                variant={theme === "light" ? "default" : "outline"}
+                onClick={() => setTheme("light")}
+                className="flex-1"
+              >
+                <Sun className="mr-2 size-4" />
+                Light
+              </Button>
+              <Button
+                variant={theme === "dark" ? "default" : "outline"}
+                onClick={() => setTheme("dark")}
+                className="flex-1"
+              >
+                <Moon className="mr-2 size-4" />
+                Dark
+              </Button>
+              <Button
+                variant={theme === "system" ? "default" : "outline"}
+                onClick={() => setTheme("system")}
+                className="flex-1"
+              >
+                <Monitor className="mr-2 size-4" />
+                System
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Separator />
+
+        {/* Location & Timezone */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Location & Timezone</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="country">Country</Label>
+                <Input
+                  id="country"
+                  value={country}
+                  onChange={(e) => setCountry(e.target.value)}
+                  placeholder="e.g. New Zealand"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="city">City</Label>
+                <Input
+                  id="city"
+                  value={city}
+                  onChange={(e) => setCity(e.target.value)}
+                  placeholder="e.g. Auckland"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Timezone</Label>
+              <Select value={timezone} onValueChange={(value) => { if (value) setTimezone(value); }}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(timezonesByRegion).map(([region, zones]) => (
+                    <SelectGroup key={region}>
+                      <SelectLabel>{region}</SelectLabel>
+                      {zones.map((tz) => (
+                        <SelectItem key={tz} value={tz}>
+                          {tz}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              onClick={handleSaveLocation}
+              disabled={isPending}
+            >
+              {isPending ? "Saving..." : "Save"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,8 +8,9 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
+import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
-import { ThemeToggle } from "@/components/theme-toggle";
+import { SettingsInitializer } from "@/components/settings-initializer";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -58,11 +59,12 @@ export default function RootLayout({
                 </Show>
                 <Show when="signed-in">
                   <UserButton />
+                  <SettingsInitializer />
                 </Show>
-                <ThemeToggle />
               </div>
             </header>
             {children}
+            <Toaster />
           </ClerkProvider>
         </ThemeProvider>
       </body>

--- a/src/components/settings-initializer.tsx
+++ b/src/components/settings-initializer.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { initializeSettingsAction } from "@/app/dashboard/settings/actions";
+
+function getCurrentPosition(): Promise<GeolocationPosition> {
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(resolve, reject, {
+      timeout: 10000,
+    });
+  });
+}
+
+async function queryGeolocationPermission(): Promise<"granted" | "prompt" | "denied"> {
+  if (!("geolocation" in navigator)) return "denied";
+  try {
+    const status = await navigator.permissions.query({ name: "geolocation" });
+    return status.state;
+  } catch {
+    return "prompt";
+  }
+}
+
+async function fetchLocationFromCoords(latitude: number, longitude: number) {
+  const res = await fetch(
+    `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${latitude}&longitude=${longitude}&localityLanguage=en`
+  );
+  if (!res.ok) return null;
+  const data = await res.json();
+  return {
+    country: data.countryName ?? "",
+    city: data.city ?? "",
+  };
+}
+
+async function detectAndSaveSettings(withGeolocation: boolean) {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  let country = "";
+  let city = timezone.split("/").pop()?.replace(/_/g, " ") ?? "";
+
+  if (withGeolocation) {
+    const position = await getCurrentPosition();
+    const location = await fetchLocationFromCoords(
+      position.coords.latitude,
+      position.coords.longitude
+    );
+    if (location) {
+      if (location.country) country = location.country;
+      if (location.city) city = location.city;
+    }
+  }
+
+  await initializeSettingsAction({ timezone, country, city });
+}
+
+function requestLocationPermission() {
+  toast("Allow location access to auto-detect your country and city.", {
+    duration: Infinity,
+    action: {
+      label: "Allow",
+      onClick: async () => {
+        try {
+          await detectAndSaveSettings(true);
+          toast.success("Location detected successfully.");
+        } catch {
+          toast.warning(
+            "Location access was denied. You can enable it in your browser's site settings."
+          );
+          await detectAndSaveSettings(false);
+        }
+      },
+    },
+    cancel: {
+      label: "Skip",
+      onClick: async () => {
+        await detectAndSaveSettings(false);
+      },
+    },
+  });
+}
+
+export function SettingsInitializer() {
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    queryGeolocationPermission().then(async (state) => {
+      if (state === "granted") {
+        try {
+          await detectAndSaveSettings(true);
+        } catch {
+          await detectAndSaveSettings(false);
+        }
+      } else if (state === "denied") {
+        await detectAndSaveSettings(false);
+        toast.warning(
+          "Location access is blocked. To auto-detect your country and city, enable location in your browser's site settings."
+        );
+      } else {
+        requestLocationPermission();
+      }
+    });
+  }, []);
+
+  return null;
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/data/user-settings.ts
+++ b/src/data/user-settings.ts
@@ -1,0 +1,23 @@
+import { eq } from "drizzle-orm";
+import db from "@/db";
+import { userSettings } from "@/db/schema";
+
+export async function getUserSettings(userId: string) {
+  return db.query.userSettings.findFirst({
+    where: eq(userSettings.userId, userId),
+  }) ?? null;
+}
+
+export async function upsertUserSettings(
+  userId: string,
+  data: { country?: string; city?: string; timezone?: string }
+) {
+  return db
+    .insert(userSettings)
+    .values({ userId, ...data })
+    .onConflictDoUpdate({
+      target: userSettings.userId,
+      set: data,
+    })
+    .returning();
+}

--- a/src/data/workouts.ts
+++ b/src/data/workouts.ts
@@ -1,4 +1,5 @@
 import { and, eq, gte, lt } from "drizzle-orm";
+import { fromZonedTime } from "date-fns-tz";
 import db from "@/db";
 import { workouts, workoutExercises, sets } from "@/db/schema";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -116,12 +117,20 @@ export async function deleteWorkout(workoutId: string, userId: string) {
     .where(and(eq(workouts.id, workoutId), eq(workouts.userId, userId)));
 }
 
-export async function getWorkoutsByDate(dateString: string) {
+export async function getWorkoutsByDate(dateString: string, timezone?: string) {
   const user = await getAuthenticatedUser();
 
   const [year, month, day] = dateString.split("-").map(Number);
-  const dayStart = new Date(year, month - 1, day);
-  const dayEnd = new Date(year, month - 1, day + 1);
+  let dayStart: Date;
+  let dayEnd: Date;
+
+  if (timezone) {
+    dayStart = fromZonedTime(new Date(year, month - 1, day), timezone);
+    dayEnd = fromZonedTime(new Date(year, month - 1, day + 1), timezone);
+  } else {
+    dayStart = new Date(year, month - 1, day);
+    dayEnd = new Date(year, month - 1, day + 1);
+  }
 
   return db.query.workouts.findMany({
     where: and(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -89,3 +89,15 @@ export const setsRelations = relations(sets, ({ one }) => ({
     references: [workoutExercises.id],
   }),
 }));
+
+// ── User Settings ──────────────────────────────────────────────────────────
+
+export const userSettings = pgTable('user_settings', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: varchar('user_id', { length: 255 }).notNull().unique(),
+  country: varchar('country', { length: 255 }),
+  city: varchar('city', { length: 255 }),
+  timezone: varchar('timezone', { length: 100 }),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull().$onUpdate(() => new Date()),
+});


### PR DESCRIPTION
## Summary

Add a full user settings page with profile management, connected accounts display, appearance theme toggle, and location/timezone settings. Auto-detects user location via Browser Geolocation API on first sign-in with a Sonner toast permission flow.

## Changes

- **Settings page** (`/dashboard/settings`) with four sections: Profile, Connected Accounts, Appearance, and Location & Timezone
- **Custom profile UI** replacing Clerk's `<UserProfile />` component with shadcn/ui components (Avatar, Badge, Card) for design consistency
- **Location auto-detection** using Browser Geolocation API + BigDataCloud reverse geocoding, with Sonner toast for permission request/denied states
- **Timezone-aware workout filtering** using `date-fns-tz` to correctly filter workouts by the user's configured timezone
- **User settings schema** (`user_settings` table) with country, city, and timezone fields
- **Settings link** added to dashboard header (gear icon)
- **New shadcn/ui components**: Avatar, Select, Separator, Sonner
- **111 tests** all passing, including new settings page tests

## Related Issue

- Related to #11 

## Screenshots
AS-IS (Dashboard) | TO-BE (Dashboard)
--|--
<img width="320" src="https://github.com/user-attachments/assets/a2f04bcb-1ab9-4801-bc69-50e461456f6a" /> | <img width="320" src="https://github.com/user-attachments/assets/db232b64-b050-4519-b1e5-ba41e428fcc9" />
AS-IS (Settings) | TO-BE (Settings)
&nbsp; | <img width="320" src="https://github.com/user-attachments/assets/571df8b0-4390-49a6-bfbd-0806592589d1" />

## Notes

- The `SettingsInitializer` component in the root layout auto-initializes timezone, country, and city on first sign-in (only populates empty fields)
- BigDataCloud reverse geocoding API is free and requires no API key for client-side use
- If the user denies location permission, a warning toast guides them to browser site settings
- The `<Toaster />` component is added to the root layout for app-wide toast support

🤖 Generated with [Claude Code](https://claude.com/claude-code)