### PR TITLE
Fix dashboard default date using server UTC instead of user timezone

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { getWorkoutsByDate } from "@/data/workouts";
 import { getUserSettings } from "@/data/user-settings";
 import { getAuthenticatedUser } from "@/lib/auth";
@@ -16,7 +17,11 @@ export default async function DashboardPage({
 
   const { date: dateParam } = await searchParams;
 
-  const dateString = dateParam ?? format(new Date(), "yyyy-MM-dd");
+  const dateString = dateParam ?? (
+    settings?.timezone
+      ? formatInTimeZone(new Date(), settings.timezone, "yyyy-MM-dd")
+      : format(new Date(), "yyyy-MM-dd")
+  );
   const workouts = await getWorkoutsByDate(dateString, settings?.timezone ?? undefined);
 
   return <DashboardClient dateString={dateString} workouts={workouts} />;


### PR DESCRIPTION
## Summary

Fix incorrect dashboard date caused by server-client timezone mismatch. The Vercel server runs on UTC, so `new Date()` on the server returns a UTC-based date string instead of the user's local date.

## Changes

- Use `formatInTimeZone` from `date-fns-tz` in `src/app/dashboard/page.tsx` to calculate "today" based on the user's stored timezone setting
- Fall back to server timezone (`format(new Date(), ...)`) when no user timezone is available

## Related Issue

Fixes #13 

## Notes

- No new dependencies — `date-fns-tz` is already used in `src/data/workouts.ts`
- The user's timezone setting is already fetched on the same page (`getUserSettings`), so no additional DB calls are needed
- Users without a timezone setting will still use server UTC as before (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)