### PR TITLE
Fix back navigation from dashboard subpages losing selected date

### DIFF
--- a/__tests__/dashboard/settings/page.test.jsx
+++ b/__tests__/dashboard/settings/page.test.jsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
 }));
 
 jest.mock("next-themes", () => ({

--- a/__tests__/dashboard/workout/[workoutId]/edit/page.test.jsx
+++ b/__tests__/dashboard/workout/[workoutId]/edit/page.test.jsx
@@ -5,6 +5,7 @@ const notFoundError = new Error("NEXT_NOT_FOUND");
 jest.mock("next/navigation", () => ({
   notFound: jest.fn(() => { throw notFoundError; }),
   useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
 }));
 
 jest.mock("@/lib/auth", () => ({

--- a/__tests__/dashboard/workout/[workoutId]/page.test.jsx
+++ b/__tests__/dashboard/workout/[workoutId]/page.test.jsx
@@ -5,6 +5,7 @@ const notFoundError = new Error("NEXT_NOT_FOUND");
 jest.mock("next/navigation", () => ({
   notFound: jest.fn(() => { throw notFoundError; }),
   useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
 }));
 
 jest.mock("@/lib/auth", () => ({

--- a/__tests__/dashboard/workout/[workoutId]/workout-form.test.jsx
+++ b/__tests__/dashboard/workout/[workoutId]/workout-form.test.jsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
 }));
 
 jest.mock("date-fns", () => ({

--- a/__tests__/dashboard/workout/new/page.test.jsx
+++ b/__tests__/dashboard/workout/new/page.test.jsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn().mockReturnValue({ push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: jest.fn().mockReturnValue(new URLSearchParams()),
 }));
 
 jest.mock("date-fns", () => ({

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -64,7 +64,7 @@ export default function DashboardClient({
       <div className="mb-6 flex items-center justify-between">
         <h2 className="text-2xl font-bold">Dashboard</h2>
         <div className="flex items-center gap-2">
-          <Link href="/dashboard/workout/new">
+          <Link href={`/dashboard/workout/new?date=${dateString}`}>
             <Button>
               <FilePlusCorner className="size-4 md:hidden" />
               <span className="hidden md:inline">Log New Workout</span>
@@ -86,7 +86,7 @@ export default function DashboardClient({
               />
             </PopoverContent>
           </Popover>
-          <Link href="/dashboard/settings">
+          <Link href={`/dashboard/settings?date=${dateString}`}>
             <Button variant="outline" size="icon">
               <Settings className="size-4" />
             </Button>
@@ -105,7 +105,7 @@ export default function DashboardClient({
       ) : (
         <div className="space-y-3">
           {workouts.map((workout) => (
-            <Link key={workout.id} href={`/dashboard/workout/${workout.id}`} className="block">
+            <Link key={workout.id} href={`/dashboard/workout/${workout.id}?date=${dateString}`} className="block">
               <Card>
                 <CardHeader>
                   <div className="flex items-center justify-between">

--- a/src/app/dashboard/settings/settings-client.tsx
+++ b/src/app/dashboard/settings/settings-client.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition, useMemo } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import { useUser, useClerk } from "@clerk/nextjs";
 import { ArrowLeft, Sun, Moon, Monitor, ExternalLink } from "lucide-react";
@@ -59,6 +59,9 @@ function formatProvider(provider: string) {
 
 export default function SettingsClient({ settings }: SettingsClientProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get("date");
+  const dashboardPath = dateParam ? `/dashboard?date=${dateParam}` : "/dashboard";
   const { user } = useUser();
   const clerk = useClerk();
   const { theme = "system", setTheme } = useTheme();
@@ -95,7 +98,7 @@ export default function SettingsClient({ settings }: SettingsClientProps) {
   return (
     <main className="mx-auto max-w-2xl px-4 py-8">
       <div className="mb-6 flex items-center gap-3">
-        <Link href="/dashboard">
+        <Link href={dashboardPath}>
           <Button variant="outline" size="icon">
             <ArrowLeft className="size-4" />
           </Button>

--- a/src/app/dashboard/workout/[workoutId]/workout-form.tsx
+++ b/src/app/dashboard/workout/[workoutId]/workout-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { format } from "date-fns";
 import { PencilIcon, Trash2Icon, PlusIcon, CheckIcon, XIcon, CalendarIcon, CopyIcon } from "lucide-react";
@@ -65,6 +65,9 @@ export default function WorkoutForm({
   exerciseCatalog,
 }: WorkoutFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get("date");
+  const dashboardPath = dateParam ? `/dashboard?date=${dateParam}` : "/dashboard";
   const isEditing = mode === "edit";
   const [isEditingName, setIsEditingName] = useState(false);
   const [name, setName] = useState(initialName);
@@ -344,13 +347,13 @@ export default function WorkoutForm({
               {isCompleted ? "Completed" : "Complete Workout"}
             </Button>
           ) : (
-            <Link href={`/dashboard/workout/${workoutId}/edit`}>
+            <Link href={`/dashboard/workout/${workoutId}/edit${dateParam ? `?date=${dateParam}` : ""}`}>
               <Button>Edit Workout</Button>
             </Link>
           )}
           <Button
             variant="outline"
-            onClick={() => router.push("/dashboard")}
+            onClick={() => router.push(dashboardPath)}
           >
             Back to Dashboard
           </Button>

--- a/src/app/dashboard/workout/new/new-workout-form.tsx
+++ b/src/app/dashboard/workout/new/new-workout-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -28,6 +28,9 @@ function ceilToNearest30(date: Date): Date {
 
 export default function NewWorkoutForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get("date");
+  const dashboardPath = dateParam ? `/dashboard?date=${dateParam}` : "/dashboard";
   const [name, setName] = useState("");
   const [startedAt, setStartedAt] = useState<Date | null>(null);
 
@@ -50,7 +53,7 @@ export default function NewWorkoutForm() {
     setIsSubmitting(true);
     try {
       const [created] = await createWorkoutAction({ name: trimmed, startedAt: startedAt!.toISOString() });
-      router.push(created ? `/dashboard/workout/${created.id}/edit` : "/dashboard");
+      router.push(created ? `/dashboard/workout/${created.id}/edit${dateParam ? `?date=${dateParam}` : ""}` : dashboardPath);
     } catch {
       setError("Failed to create workout. Please try again.");
     } finally {
@@ -124,7 +127,7 @@ export default function NewWorkoutForm() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => router.push("/dashboard")}
+                onClick={() => router.push(dashboardPath)}
               >
                 Cancel
               </Button>


### PR DESCRIPTION
## Summary

Back navigation from dashboard subpages (Settings, Workout View/Edit/New) always redirected to `/dashboard` without the `date` query parameter, causing users to lose their selected date context and land on today's date.

## Changes

- Pass `date` query parameter from dashboard to all subpage links (`dashboard-client.tsx`)
- Read `date` param via `useSearchParams()` in workout form, new workout form, and settings pages
- Use preserved `date` param when navigating back to dashboard ("Back to Dashboard", "Cancel", back arrow)
- Carry `date` param through internal navigation (e.g., View → Edit transition)
- Graceful fallback to `/dashboard` (today's date) when no `date` param is present
- Updated 5 test files to mock `useSearchParams` in `next/navigation`

## Related Issue

Closes #15

## Notes

- No UI changes — the fix is purely in navigation/URL behavior
- All 111 existing tests pass
- When `date` param is absent (e.g., direct URL access), behavior falls back to the existing default (today's date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)