### PR TITLE
Fix new workout form ignoring dashboard selected date

### DIFF
--- a/src/app/dashboard/workout/new/new-workout-form.tsx
+++ b/src/app/dashboard/workout/new/new-workout-form.tsx
@@ -35,8 +35,17 @@ export default function NewWorkoutForm() {
   const [startedAt, setStartedAt] = useState<Date | null>(null);
 
   useEffect(() => {
+    if (dateParam) {
+      const parsed = new Date(dateParam + "T00:00:00");
+      const today = new Date();
+      if (format(parsed, "yyyy-MM-dd") !== format(today, "yyyy-MM-dd")) {
+        parsed.setHours(9, 0, 0, 0);
+        setStartedAt(parsed);
+        return;
+      }
+    }
     setStartedAt(ceilToNearest30(new Date()));
-  }, []);
+  }, [dateParam]);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 


### PR DESCRIPTION
## Summary

When navigating from a dashboard with a specific date (`/dashboard?date=2026-03-10`) and clicking "Log New Workout", the form's `startedAt` field was always initialized to the current time. This fix makes the form respect the selected dashboard date.

## Changes

- Updated `useEffect` in `new-workout-form.tsx` to check the `date` query parameter when initializing `startedAt`
- If `dateParam` exists and is **not today**: sets `startedAt` to that date at 09:00 AM
- If `dateParam` is absent or is **today**: keeps existing behavior (`ceilToNearest30(new Date())`)
- Added `dateParam` to the `useEffect` dependency array

## Related Issue

Closes #17

## Notes

- No UI layout changes — the form looks identical, only the pre-filled date value changes based on the URL parameter
- All 111 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)