### PR TITLE
Fix home page redirect for unauthenticated users

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,5 +21,11 @@
       "mcp__neon__run_sql",
       "mcp__neon__run_sql_transaction"
     ]
+  },
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "vercel@claude-plugins-official": true
   }
 }

--- a/__tests__/page.test.jsx
+++ b/__tests__/page.test.jsx
@@ -11,8 +11,8 @@ jest.mock("next/link", () => {
   return MockLink;
 });
 
-jest.mock("@/lib/auth", () => ({
-  getAuthenticatedUser: jest.fn(),
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
 }));
 
 jest.mock("@/components/ui/button", () => ({
@@ -33,13 +33,13 @@ jest.mock("lucide-react", () => ({
 }));
 
 import { redirect } from "next/navigation";
-import { getAuthenticatedUser } from "@/lib/auth";
+import { auth } from "@clerk/nextjs/server";
 import Home from "@/app/page";
 
 describe("Home", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getAuthenticatedUser.mockRejectedValue(new Error("Not authenticated"));
+    auth.mockResolvedValue({ userId: null });
   });
 
   it("renders the home page", async () => {
@@ -61,7 +61,7 @@ describe("Home", () => {
   });
 
   it("redirects to dashboard when authenticated", async () => {
-    getAuthenticatedUser.mockResolvedValue({ id: "user-1" });
+    auth.mockResolvedValue({ userId: "user-1" });
 
     await Home();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,14 @@
 import { redirect } from "next/navigation";
-import { getAuthenticatedUser } from "@/lib/auth";
+import { auth } from "@clerk/nextjs/server";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Dumbbell, ListChecks, CalendarSearch } from "lucide-react";
 
 export default async function Home() {
-  let isAuthenticated = false;
-  try {
-    await getAuthenticatedUser();
-    isAuthenticated = true;
-  } catch {
-    // User is not authenticated, continue to render homepage
-  }
+  const { userId } = await auth();
 
-  if (isAuthenticated) {
+  if (userId) {
     redirect("/dashboard");
   }
 


### PR DESCRIPTION
## Summary

Fix the home page (`/`) automatically redirecting unauthenticated users to the Clerk sign-in page instead of displaying the public landing page.

## Changes

- Replace `getAuthenticatedUser()` (which calls `auth.protect()`) with `auth()` in `src/app/page.tsx`
- `auth()` returns the session state without forcing a redirect, allowing the landing page to render for unauthenticated visitors
- Authenticated users are still redirected to `/dashboard` as before

## Related Issue

Closes #26

## Notes

- `auth.protect()` forces a redirect to the Clerk sign-in page for unauthenticated users — it should only be used on protected routes
- `auth()` simply reads the authentication state without side effects — appropriate for public pages that conditionally check auth status
- The `try/catch` in the original code did not catch the redirect because Next.js `redirect()` throws a special error that propagates through catch blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)